### PR TITLE
Updates to allow for neuroglancer multires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .pydevproject
 __pycache__/
+vol2mesh.egg-info/

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -7,5 +7,8 @@
 python:
   - 3.7
 
+dependencies:
+  - trimesh=3.9.8=pyh44b312d_0
+
 pin_run_as_build:
   python: x.x

--- a/vol2mesh/mesh.py
+++ b/vol2mesh/mesh.py
@@ -1096,15 +1096,12 @@ class Mesh:
     def trim(self):
         min_box = self.fragment_origin
         max_box = self.fragment_origin + self.fragment_shape
-        #print(f"boxes: {min_box} {max_box} {self.vertices_zyx.shape} {np.amax(self.vertices_zyx,0)} {np.amin(self.vertices_zyx,0)}")
-        # Define plane normals and create a trimesh object.
+
         nyz, nxz, nxy = np.eye(3)
         verts = self.vertices_zyx[:,::-1]
         faces = self.faces
         trimesh_mesh = trimesh.Trimesh(verts,faces)
-        #print(f"before {type(verts)} {type(faces)} {np.amax(verts,axis=0)} {min_box} {max_box} {len(verts)} {faces.shape} {faces.reshape(-1).shape}")
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=nyz, plane_origin=min_box)
-        #verts, faces = trimesh.intersections.slice_faces_plane(verts, faces, plane_normal=nyz, plane_origin=min_box) DIDNT WORK WITH JUST FACES AND VERTS
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=-nyz, plane_origin=max_box)
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=nxz, plane_origin=min_box)
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimeshvol_mesh, plane_normal=-nxz, plane_origin=max_box)
@@ -1114,7 +1111,6 @@ class Mesh:
         self.faces = trimesh_mesh.faces
         self.box = np.array( [ self.vertices_zyx.min(axis=0),
                                    np.ceil( self.vertices_zyx.max(axis=0) ) ] ).astype(np.int32)
-        #self.recompute_normals() #only necessary if trimming mesh fragments and doing lz4 compression?
 
 
     @classmethod

--- a/vol2mesh/mesh.py
+++ b/vol2mesh/mesh.py
@@ -1096,6 +1096,7 @@ class Mesh:
     def trim(self):
         min_box = self.fragment_origin
         max_box = self.fragment_origin + self.fragment_shape
+        #print(f"boxes: {min_box} {max_box} {self.vertices_zyx.shape} {np.amax(self.vertices_zyx,0)} {np.amin(self.vertices_zyx,0)}")
         # Define plane normals and create a trimesh object.
         nyz, nxz, nxy = np.eye(3)
         verts = self.vertices_zyx[:,::-1]
@@ -1106,11 +1107,14 @@ class Mesh:
         #verts, faces = trimesh.intersections.slice_faces_plane(verts, faces, plane_normal=nyz, plane_origin=min_box) DIDNT WORK WITH JUST FACES AND VERTS
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=-nyz, plane_origin=max_box)
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=nxz, plane_origin=min_box)
-        trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=-nxz, plane_origin=max_box)
+        trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimeshvol_mesh, plane_normal=-nxz, plane_origin=max_box)
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=nxy, plane_origin=min_box)
         trimesh_mesh = trimesh.intersections.slice_mesh_plane(trimesh_mesh, plane_normal=-nxy, plane_origin=max_box)
-        self.vertices_zyx = trimesh_mesh.vertices[:,::-1]
+        self.vertices_zyx = trimesh_mesh.vertices[:,::-1]#.astype('float32')
         self.faces = trimesh_mesh.faces
+        self.box = np.array( [ self.vertices_zyx.min(axis=0),
+                                   np.ceil( self.vertices_zyx.max(axis=0) ) ] ).astype(np.int32)
+        #self.recompute_normals() #only necessary if trimming mesh fragments and doing lz4 compression?
 
 
     @classmethod

--- a/vol2mesh/tests/test_mesh.py
+++ b/vol2mesh/tests/test_mesh.py
@@ -88,7 +88,7 @@ def test_basic(binary_vol_input):
     unserialized = mesh.from_buffer(serialized, 'drc')
     assert len(unserialized.vertices_zyx) == len(mesh.vertices_zyx)
 
-    mesh = Mesh.from_binary_vol( binary_vol, data_box, mesh_origin = np.asarray(data_box[0]), fragment_shape = np.asarray(data_box[1]), fragment_origin = np.asarray(data_box[0]))
+    mesh = Mesh.from_binary_vol( binary_vol, data_box, fragment_shape = np.asarray(data_box[1]), fragment_origin = np.asarray(data_box[0]))
     serialized = mesh.serialize(fmt='custom_drc')
     unserialized = mesh.from_buffer(serialized, 'drc')
     assert len(unserialized.vertices_zyx) == len(mesh.vertices_zyx)
@@ -97,6 +97,19 @@ def test_basic(binary_vol_input):
     unserialized = mesh.from_buffer(serialized, 'ngmesh')
     assert len(unserialized.vertices_zyx) == len(mesh.vertices_zyx)
     
+def test_trim(binary_vol_input):
+    mesh = Mesh.from_binary_vol( binary_vol_input[0])
+    mesh.fragment_origin = np.array([25,25,25])
+    mesh.fragment_shape = np.array([50,50,50])
+    num_faces = len(mesh.faces)
+    mesh.trim()
+    assert len(mesh.faces) < num_faces
+
+    mesh = Mesh.from_binary_vol( binary_vol_input[0])
+    mesh.fragment_origin = np.array([125,125,125])
+    mesh.fragment_shape = np.array([50,50,50])
+    mesh.trim()
+    assert len(mesh.faces) == 0
 
 def test_blockwise(binary_vol_input):
     binary_vol, data_box, nonzero_box = binary_vol_input
@@ -501,7 +514,6 @@ def test_compress(binary_vol_input):
 
 
     mesh = copy.deepcopy(mesh_orig)
-    mesh.mesh_origin = np.asarray(data_box[0])
     mesh.fragment_shape = np.asarray(data_box[1])
     mesh.fragment_origin = np.asarray(data_box[0])
     size = mesh.compress('custom_draco')

--- a/vol2mesh/tests/test_mesh.py
+++ b/vol2mesh/tests/test_mesh.py
@@ -88,6 +88,11 @@ def test_basic(binary_vol_input):
     unserialized = mesh.from_buffer(serialized, 'drc')
     assert len(unserialized.vertices_zyx) == len(mesh.vertices_zyx)
 
+    mesh = Mesh.from_binary_vol( binary_vol, data_box, mesh_origin = np.asarray(data_box[0]), fragment_shape = np.asarray(data_box[1]), fragment_origin = np.asarray(data_box[0]))
+    serialized = mesh.serialize(fmt='custom_drc')
+    unserialized = mesh.from_buffer(serialized, 'drc')
+    assert len(unserialized.vertices_zyx) == len(mesh.vertices_zyx)
+
     serialized = mesh.serialize(fmt='ngmesh')
     unserialized = mesh.from_buffer(serialized, 'ngmesh')
     assert len(unserialized.vertices_zyx) == len(mesh.vertices_zyx)
@@ -223,6 +228,9 @@ def test_empty_mesh():
     assert len(mesh.vertices_zyx) == len(mesh.normals_zyx) == len(mesh.faces) == 0
 
     mesh.serialize(fmt='drc')
+    assert len(mesh.vertices_zyx) == len(mesh.normals_zyx) == len(mesh.faces) == 0
+
+    mesh.serialize(fmt='custom_drc')
     assert len(mesh.vertices_zyx) == len(mesh.normals_zyx) == len(mesh.faces) == 0
 
     mesh.compress()
@@ -486,6 +494,17 @@ def test_compress(binary_vol_input):
     # Draco is lossy, so we can't compare exactly.
     # Just make sure the arrays are at least of the correct shape.
     size = mesh.compress('draco')
+    assert size < uncompressed_size
+    assert (mesh.faces.shape == mesh_orig.faces.shape)
+    assert (mesh.vertices_zyx.shape == mesh_orig.vertices_zyx.shape)
+    assert (mesh.normals_zyx.shape == mesh_orig.normals_zyx.shape)
+
+
+    mesh = copy.deepcopy(mesh_orig)
+    mesh.mesh_origin = np.asarray(data_box[0])
+    mesh.fragment_shape = np.asarray(data_box[1])
+    mesh.fragment_origin = np.asarray(data_box[0])
+    size = mesh.compress('custom_draco')
     assert size < uncompressed_size
     assert (mesh.faces.shape == mesh_orig.faces.shape)
     assert (mesh.vertices_zyx.shape == mesh_orig.vertices_zyx.shape)


### PR DESCRIPTION
-Added functions to call draco compression using neuroglancer multiresolution mesh specifications.

-Added `mesh_origin`, `fragment_origin` and `fragment_shape` to mesh objects, necessary for converting to draco multiresolution mesh format.

-Added trimming to ensure all mesh faces/vertices are truncated at box edge.